### PR TITLE
Update setup.py license to BSD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author='RedTurtle Developers',
     url = 'https://github.com/RedTurtle/js.bootstrap',
     author_email='sviluppoplone@redturtle.it',
-    license='GPL',
+    license='BSD',
     packages=find_packages(),
     namespace_packages=['js'],
     include_package_data=True,


### PR DESCRIPTION
The LICENSE.txt file is BSD-style, but setup.py lists the license as "GPL".

I'm hoping this was meant to be BSD licensed as the LICENSE.txt file indicates, which seems to the the commonly chosen license for Fanstatic packages.  If it is meant to be GPL, I won't be able to use this packaging of the library, since I can't apply the GPL license to the rest of my code.
