### PR TITLE
A package on pypi does not include any source maps

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 recursive-include js/bootstrap/resources/fonts *.*
-recursive-include js/bootstrap/resources *.js *.css *.png
+recursive-include js/bootstrap/resources *.js *.css *.png *.map
 recursive-include js/bootstrap *.txt
 include *.txt *.rst


### PR DESCRIPTION
At the bottom bootstrap.css has a line:

``` css
/*# sourceMappingURL=bootstrap.css.map */
```

But the package does not include any source maps.
