### PR TITLE
fix failed doctest

### DIFF
--- a/js/bootstrap/test_bootstrap.txt
+++ b/js/bootstrap/test_bootstrap.txt
@@ -21,7 +21,8 @@ you can include the bootstrap_theme css::
 
 Render the inclusion::
 
-  >>> print needed.render()
+  >>> from fanstatic import Inclusion
+  >>> print Inclusion(needed).render()
   <link rel="stylesheet" type="text/css" href="http://localhost/fanstatic/bootstrap/css/bootstrap.css" />
   <link rel="stylesheet" type="text/css" href="http://localhost/fanstatic/bootstrap/css/bootstrap-theme.css" />
   <script type="text/javascript" src="http://localhost/fanstatic/jquery/jquery.js"></script>

--- a/js/bootstrap/test_bootstrap.txt
+++ b/js/bootstrap/test_bootstrap.txt
@@ -22,7 +22,7 @@ you can include the bootstrap_theme css::
 Render the inclusion::
 
   >>> from fanstatic import Inclusion
-  >>> print Inclusion(needed).render()
+  >>> print(Inclusion(needed).render())
   <link rel="stylesheet" type="text/css" href="http://localhost/fanstatic/bootstrap/css/bootstrap.css" />
   <link rel="stylesheet" type="text/css" href="http://localhost/fanstatic/bootstrap/css/bootstrap-theme.css" />
   <script type="text/javascript" src="http://localhost/fanstatic/jquery/jquery.js"></script>


### PR DESCRIPTION
```
Doctest: test_bootstrap.txt ... FAIL

======================================================================
FAIL: js/bootstrap/test_bootstrap.txt
Doctest: test_bootstrap.txt
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/doctest.py", line 2201, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for test_bootstrap.txt
  File "js/bootstrap/test_bootstrap.txt", line 0

----------------------------------------------------------------------
File "js/bootstrap/test_bootstrap.txt", line 24, in test_bootstrap.txt
Failed example:
    print needed.render()
Exception raised:
    Traceback (most recent call last):
      File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/doctest.py", line 1289, in __run
        compileflags, 1) in test.globs
      File "<doctest test_bootstrap.txt[6]>", line 1, in <module>
        print needed.render()
    AttributeError: 'NeededResources' object has no attribute 'render'
```